### PR TITLE
Fixing some Readme and Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ This repo hosts a service that can be added to a Realm Object Server instance to
 
 ## Usage
 
-Clone the repo and run `npm start`. To debug the app, open the folder in Visual Studio Code and run the debugger (F5).
-
-To run the service as part of a ROS instance include the following code in your service `init` file:
+1. First install Realm Object Server with `npm install -g realm-object-server`
+2. Create a new server with `ros init my-app`
+3. Add `realm-graphql-service` as a dependency by running either `npm install realm-graphql-service -S` or if you have yarn `yarn add realm-graphql-service`
+4. Import the service and add it to your server instance like so:
 
 ```typescript
 import { BasicServer } from 'realm-object-server'

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "docs": "node_modules/typedoc/bin/typedoc src"    
   },
   "peerDependencies": {
-    "realm-object-server": ">=2.1.0",
-    "express": ">=4.15.3"
+    "realm-object-server": ">=2.1.0"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
@@ -74,8 +73,6 @@
     "lru-cache": "^4.1.1",
     "pluralize": "^7.0.0",
     "reconnecting-websocket": "^3.2.2",
-    "subscriptions-transport-ws": "^0.9.1",
-    "superagent": "^3.8.1",
-    "urijs": "^1.19.0"
+    "subscriptions-transport-ws": "^0.9.1"
   }
 }


### PR DESCRIPTION
1. Removing superagent and urijs (they're already included in realm-object-server as a peer dependency)
2. Updating information about installation