### PR TITLE
Ignore properties containing underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Breaking Changes
 
+# 2.5.1
+
+### Bug fixes
+* Fixed an issue that caused querying realms with types/properties that started with double underscores to throw
+an obscure type error.
+
 # 2.5.0
 
 ### Enahancements

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "realm-graphql-service",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -822,7 +822,7 @@
             "dev": true,
             "requires": {
                 "base64-js": "0.0.8",
-                "ieee754": "1.1.11",
+                "ieee754": "1.1.12",
                 "isarray": "1.0.0"
             }
         },
@@ -2578,9 +2578,9 @@
             }
         },
         "ieee754": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-            "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+            "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
             "dev": true
         },
         "indent-string": {
@@ -3704,9 +3704,9 @@
             }
         },
         "nodemailer": {
-            "version": "4.6.5",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-4.6.5.tgz",
-            "integrity": "sha512-+bt+BgmnOXDz1uIaWXfXuTESth8UHkhtu7+X8+X2W+CHAn0AuuCyCk854qnathYQLWEC2jkpx7/pkVHcfmLKDw==",
+            "version": "4.6.6",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-4.6.6.tgz",
+            "integrity": "sha512-sIcM/Do0XBJmu7ruENLoR+4TCk0B4C1ftqRjWrVeoez9Dt23SmL9bXKqswVqyxuT/RdK8TKWciZvxHykerXCRw==",
             "dev": true
         },
         "nopt": {
@@ -4248,9 +4248,9 @@
             }
         },
         "realm-object-server": {
-            "version": "3.6.5",
-            "resolved": "https://registry.npmjs.org/realm-object-server/-/realm-object-server-3.6.5.tgz",
-            "integrity": "sha1-MZotRuDAyAy0MbZvclXnbs1g2Uc=",
+            "version": "3.6.6",
+            "resolved": "https://registry.npmjs.org/realm-object-server/-/realm-object-server-3.6.6.tgz",
+            "integrity": "sha1-1dr6a5Az6in8G0NVbBRGNnE5yLA=",
             "dev": true,
             "requires": {
                 "@types/cors": "2.8.4",
@@ -4281,13 +4281,13 @@
                 "moment": "2.22.2",
                 "morgan": "1.9.0",
                 "node-rsa": "0.4.2",
-                "nodemailer": "4.6.5",
+                "nodemailer": "4.6.6",
                 "npm-which": "3.0.1",
                 "path-to-regexp": "2.2.1",
                 "prom-client": "11.0.0",
                 "promptly": "2.2.0",
                 "realm": "2.7.0",
-                "realm-sync-server": "https://static.realm.io/downloads/node/realm-sync-server-3.5.0.tgz",
+                "realm-sync-server": "https://static.realm.io/downloads/node/realm-sync-server-3.5.1.tgz",
                 "resolve": "1.7.1",
                 "resolve-bin": "0.4.0",
                 "semver": "5.5.0",
@@ -4308,8 +4308,8 @@
                     "dev": true
                 },
                 "realm-sync-server": {
-                    "version": "https://static.realm.io/downloads/node/realm-sync-server-3.5.0.tgz",
-                    "integrity": "sha512-QQvehNwv/sJg3sjK7SRp981uQMIX8xLRlSY8z77+xQrUuicLDj333UA/QFDBI8K6iymtiGqKsIfIPa/CTAkDJA==",
+                    "version": "https://static.realm.io/downloads/node/realm-sync-server-3.5.1.tgz",
+                    "integrity": "sha512-xopawIbfpWthphtOWF90c5ui6Z5GcJJ3JB740rIFOQ70Ky4kn9fCv/nHbmloqZ4/ILBEBadbvbDGva57YB/92w==",
                     "dev": true
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4248,9 +4248,9 @@
             }
         },
         "realm-object-server": {
-            "version": "3.6.6",
-            "resolved": "https://registry.npmjs.org/realm-object-server/-/realm-object-server-3.6.6.tgz",
-            "integrity": "sha1-1dr6a5Az6in8G0NVbBRGNnE5yLA=",
+            "version": "3.6.7",
+            "resolved": "https://registry.npmjs.org/realm-object-server/-/realm-object-server-3.6.7.tgz",
+            "integrity": "sha1-teDn3Cn0Ri63J4ynjbYCDGwUMj4=",
             "dev": true,
             "requires": {
                 "@types/cors": "2.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realm-graphql-service",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "GraphQL API service for the Realm Object Server",
   "repository": "https://github.com/realm/realm-object-server-graphql",
   "license": "SEE LICENSE IN https://realm.io/legal/developer-license-terms/",
@@ -58,7 +58,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^7.1.3",
     "mocha": "^5.2.0",
-    "realm-object-server": "^3.6.5",
+    "realm-object-server": "^3.6.6",
     "ts-node": "^6.1.0",
     "tslint": "^5.10.0",
     "tslint-eslint-rules": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "docs": "node_modules/typedoc/bin/typedoc src"
   },
   "peerDependencies": {
-    "realm-object-server": ">=3.6.0"
+    "realm-object-server": ">=3.6.7"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
@@ -58,7 +58,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^7.1.3",
     "mocha": "^5.2.0",
-    "realm-object-server": "^3.6.6",
+    "realm-object-server": "^3.6.7",
     "ts-node": "^6.1.0",
     "tslint": "^5.10.0",
     "tslint-eslint-rules": "^5.3.1",


### PR DESCRIPTION
Fixes https://github.com/realm/realm-graphql-service/issues/54
Fixes https://github.com/realm/realm-graphql-service/issues/51

This will remove such properties/types from the GraphQL schema. There are ways to preserve and rename them, but it seems quite confusing and unless someone explicitly requests it, I believe this is the safer approach.